### PR TITLE
Fix nextjs version conflict

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.0",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.284.0",
-    "next": "13.5.6",
+    "next": "13.5.7",
     "qrcode": "^1.5.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
-    "eslint-config-next": "^13.5.6",
+    "eslint-config-next": "^13.5.7",
     "postcss": "^8.4.32",
     "prettier": "^3.2.5",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- bump Next.js to 13.5.7 to satisfy @clerk/nextjs peer dependency
- keep eslint-config-next in sync

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534f2d5658832f8907ce1af1adefb6