### PR TITLE
Fix react-toastify version in web app

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.0",
-    "react-toastify": "^9.2.0",
+    "react-toastify": "9.1.3",
     "tailwindcss": "^3.4.1",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
## Summary
- set correct `react-toastify` version in `apps/web/package.json`

## Testing
- `npm install` *(fails: 403 Forbidden, likely due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc2fdaac832f90f84cdb2121efc8