### PR TITLE
Fix missing TypeScript types

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,7 +42,8 @@
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
-    "prisma": "^5.13.0"
+    "prisma": "^5.13.0",
+    "@types/react": "^18.2.65"
   },
   "optionalDependencies": {
     "husky": "^9.0.9"


### PR DESCRIPTION
## Summary
- add `@types/react` to web workspace to satisfy Next.js

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf184430832f80567b56ea17e493