### PR TITLE
Fix missing framer-motion dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.0",
+    "framer-motion": "^11.0.0",
     "react-toastify": "9.1.3",
     "tailwindcss": "^3.4.1",
     "zod": "^3.22.4"


### PR DESCRIPTION
## Summary
- add framer-motion dependency to `apps/web`

## Testing
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/react-toastify)*

------
https://chatgpt.com/codex/tasks/task_e_68544c89509c832faa84dd3863291097